### PR TITLE
Generalized GitHub actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,9 +29,9 @@ jobs:
 
             - name: Run Ruff
               run: |
-                ruff tello_edu_protocol/
+                ruff .
 
             - name: Run Pytest
               run: |
                 pip install .
-                pytest tests/
+                pytest .


### PR DESCRIPTION
The GitHub pre-commit hooks were failing in nested directories, so the test hooks have been generalized to run in any directory within the repository.